### PR TITLE
address E_WARNING about no Auth/SASL.php

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -190,7 +190,7 @@ class Net_SMTP
 
         /* Include the Auth_SASL package.  If the package is available, we
          * enable the authentication methods that depend upon it. */
-        if (@include_once 'Auth/SASL.php') {
+        if (file_exists('Auth/SASL.php')) {
             $this->setAuthMethod('CRAM-MD5', array($this, 'authCramMD5'));
             $this->setAuthMethod('DIGEST-MD5', array($this, 'authDigestMD5'));
         }


### PR DESCRIPTION
on PHP7.1

event: include_once(Auth/SASL.php): failed to open stream: No such file or directory
url: https://apps.fedco-usa.com/portal/public/sales/submittal/add/50632
file: /var/www/html/portal/vendor/pear/net_smtp/Net/SMTP.php
line: 174
error_type: E_WARNING
trace: #0 /var/www/html/portal/vendor/pear/net_smtp/Net/SMTP.php(174)